### PR TITLE
fix: use https endpoints

### DIFF
--- a/lib/tjplurk.rb
+++ b/lib/tjplurk.rb
@@ -1,7 +1,7 @@
 require 'tjplurk/api'
 module Tjplurk
   OAUTH_OPTIONS = {
-    site:               'http://www.plurk.com',
+    site:               'https://www.plurk.com',
     request_token_path: '/OAuth/request_token',
     access_token_path:  '/OAuth/access_token',
     authorize_path:     '/OAuth/authorize'


### PR DESCRIPTION
all plurk api use https from 2017/05/01 https://www.plurk.com/p/m3l7qh